### PR TITLE
Update gulpfile.js to include (yml|yaml) files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,10 +3,13 @@ var gulp = require('gulp');
 var SwaggerParser = require('swagger-parser');
 
 gulp.task('test', function() {
-  globby(['./specifications/**/*.(json|yml)']).then(function(specifications) {
+  var patterns = ['./specifications/*/swagger.{json,yml,yaml}'];
+  globby(patterns).then(function(specifications) {
     specifications.forEach(function(specification) {
       SwaggerParser.validate(specification, function(err, data) {
         if (err) { throw err; }
+        console.log(specification);
+        console.log(data);
       });
     });
   });


### PR DESCRIPTION
No review steps.

The gulp 'test' task was using the pattern matching for globby
incorrectly. The patterns have been updated to include any pattern
matching `swagger.(json|yml|yaml)`.